### PR TITLE
Change 2 function calls to not be global

### DIFF
--- a/microparsel.lua
+++ b/microparsel.lua
@@ -229,7 +229,7 @@ do -- Define simple parsers and combinators
     end
 
     function P.charPred(description, predicate)
-        return try(P.any:chain(function(value)
+        return P.try(P.any:chain(function(value)
             if predicate(value) then
                 return Either.right(value)
             else
@@ -288,7 +288,7 @@ do -- Define simple parsers and combinators
             function(input)
                 result, value = parser.parseFunc(input)
                 if value:isRight() then
-                    extraResults = many(parser):parse(input)
+                    extraResults = P.many(parser):parse(input)
                     table.insert(extraResults, 1, result)
                 end
             end


### PR DESCRIPTION
These 2 function calls act as though a global function has been defined, when the functions are actually located in the P table. Added "P." in front of the calls to fix the issue.